### PR TITLE
CUDA Toolkit

### DIFF
--- a/cuda_12_6_1_ubuntu_24.yaml
+++ b/cuda_12_6_1_ubuntu_24.yaml
@@ -7,7 +7,7 @@
 # sudo mv cuda-ubuntu2404.pin /etc/apt/preferences.d/cuda-repository-pin-600
 - name: Setup CUDA repository pin
   become: true
-  ansible.bultin.get_url:
+  ansible.builtin.get_url:
     url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-ubuntu2404.pin
     dest: /etc/apt/preferences.d/cuda-repository-pin-600
     mode: '0440'
@@ -20,14 +20,14 @@
 # sudo cp /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg /usr/share/keyrings/
 - name: Add CUDA GPG APT key
   become: true
-  apt_key:
+  ansible.builtin.apt_key:
     file: /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg
 # sudo apt-get update
 # sudo apt-get -y install cuda-toolkit-12-6
 # sudo apt-get install -y nvidia-open
 - name: Add CUDA Components
   become: true
-  apt:
+  ansible.builtin.apt:
     pkg:
       - cuda-toolkit-12-6
       - nvidia-open

--- a/cuda_12_6_1_ubuntu_24.yaml
+++ b/cuda_12_6_1_ubuntu_24.yaml
@@ -21,7 +21,7 @@
 - name: Add CUDA GPG APT key
   become: true
   ansible.builtin.apt_key:
-    file: /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg
+    file: /var/cuda-repo-ubuntu2404-12-6-local/cuda-1E1DCD98-keyring.gpg
 # sudo apt-get update
 # sudo apt-get -y install cuda-toolkit-12-6
 # sudo apt-get install -y nvidia-open

--- a/cuda_12_6_1_ubuntu_24.yaml
+++ b/cuda_12_6_1_ubuntu_24.yaml
@@ -20,8 +20,9 @@
 # sudo cp /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg /usr/share/keyrings/
 - name: Add CUDA GPG APT key
   become: true
-  ansible.builtin.apt_key:
-    file: /var/cuda-repo-ubuntu2404-12-6-local/cuda-1E1DCD98-keyring.gpg
+  ansible.builtin.copy:
+    src: /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg
+    dest: /usr/share/keyrings/
 # sudo apt-get update
 # sudo apt-get -y install cuda-toolkit-12-6
 # sudo apt-get install -y nvidia-open

--- a/cuda_12_6_1_ubuntu_24.yaml
+++ b/cuda_12_6_1_ubuntu_24.yaml
@@ -21,7 +21,7 @@
 - name: Add CUDA GPG APT key
   become: true
   ansible.builtin.copy:
-    src: /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg
+    src: /var/cuda-repo-ubuntu2404-12-6-local/cuda-1E1DCD98-keyring.gpg
     dest: /usr/share/keyrings/
 # sudo apt-get update
 # sudo apt-get -y install cuda-toolkit-12-6

--- a/cuda_12_6_1_ubuntu_24.yaml
+++ b/cuda_12_6_1_ubuntu_24.yaml
@@ -1,0 +1,35 @@
+######
+###### Each of the comments before the Ansible blocks were pulled directly from https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=24.04&target_type=deb_local.
+###### They indicate the step as suggested by NVIDIA.  The blocks below adapt them into ansible configs.
+######
+
+# wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-ubuntu2404.pin
+# sudo mv cuda-ubuntu2404.pin /etc/apt/preferences.d/cuda-repository-pin-600
+- name: Setup CUDA repository pin
+  become: true
+  ansible.bultin.get_url:
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-ubuntu2404.pin
+    dest: /etc/apt/preferences.d/cuda-repository-pin-600
+    mode: '0440'
+# wget https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda-repo-ubuntu2404-12-6-local_12.6.1-560.35.03-1_amd64.deb
+# sudo dpkg -i cuda-repo-ubuntu2404-12-6-local_12.6.1-560.35.03-1_amd64.deb
+- name: Setup CUDA Repo
+  become: true
+  ansible.builtin.apt:
+    deb: https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda-repo-ubuntu2404-12-6-local_12.6.1-560.35.03-1_amd64.deb
+# sudo cp /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg /usr/share/keyrings/
+- name: Add CUDA GPG APT key
+  become: true
+  apt_key:
+    file: /var/cuda-repo-ubuntu2404-12-6-local/cuda-*-keyring.gpg
+# sudo apt-get update
+# sudo apt-get -y install cuda-toolkit-12-6
+# sudo apt-get install -y nvidia-open
+- name: Add CUDA Components
+  become: true
+  apt:
+    pkg:
+      - cuda-toolkit-12-6
+      - nvidia-open
+    state: latest
+    update_cache: true

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -19,3 +19,4 @@
         - ca-certificates
         - curl
   - import_tasks: docker_ubuntu_24.yaml
+  - import_tasks: cuda_12_6_1_ubuntu_24.yaml


### PR DESCRIPTION
This the first of two pull requests necessary to get fully access to CUDA on waiter.  This one installs all the necessary components to get CUDA on the host.

It does not install the components necessary to use CUDA in Docker.