### PR TITLE
Update waiter_users.yaml

### DIFF
--- a/waiter_users.yaml
+++ b/waiter_users.yaml
@@ -81,6 +81,8 @@ users:
       - rdp_users
       - cuda
       - label_studio_admin
+    sudo_allow:
+      - /usr/bin/mount -t cifs ~*
   - username: d.zuberi
     name: Danial Zuberi
     authorized_keys:


### PR DESCRIPTION
Allow `c.crutchfield` to run `mount` for `cifs` within the user directory.